### PR TITLE
fix: all-in-one defensive null checks for Spectral

### DIFF
--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -29,7 +29,7 @@ rules:
     severity: warn
     recommended: true
     given: >-
-      $..[parameters][?(@.in == "header" && @.name.match(/Cache-Control/i))]
+      $..[parameters][?(@ && @.in == "header" && @.name && @.name.match && @.name.match(/Cache-Control/i))]
     then:
     -  field: description
        function: truthy
@@ -45,7 +45,7 @@ rules:
     message: >-
       [RFC7234] Cache usage in responses SHOULD be documented in Cache-Control and/or Expires. {{error}}
     given: >-
-      $..[responses][?(@property[0] == "2" )][headers].[?(@property.match(/Cache-Control|Expires/i))]
+      $..[responses][?(@property[0] == "2" )][headers].[?(@property && @property.match && @property.match(/Cache-Control|Expires/i))]
 
   cache-responses-indeterminate-behavior:
     <<: *cache-control

--- a/rules/casing.yml
+++ b/rules/casing.yml
@@ -24,7 +24,7 @@ rules:
     severity: hint
     recommended: true
     given:
-    - $..[parameters][?(@.in=="header")].name
+    - $..[parameters][?(@ && @.in=="header")].name
     then:
       function: casing
       functionOptions:

--- a/rules/headers.yml
+++ b/rules/headers.yml
@@ -8,7 +8,7 @@ rules:
       {{error}} in {{path}} {{value}}
     severity: error
     given:
-      - "$..parameters[?(@.in == 'header')].name"
+      - "$..parameters[?(@ && @.in == 'header')].name"
       - $..[responses][*].headers.*~
     then:
       function: pattern
@@ -21,7 +21,7 @@ rules:
       'HTTP' headers SHOULD NOT start with 'X-' RFC6648.
     severity: warn
     given:
-      - "$..parameters[?(@.in == 'header')].name"
+      - "$..parameters[?(@ && @.in == 'header')].name"
     message: |-
       [RFC6648] HTTP header '{{value}}' SHOULD NOT start with 'X-' in {{path}}
     recommended: true

--- a/rules/https.yml
+++ b/rules/https.yml
@@ -24,8 +24,8 @@ rules:
       Non-sandbox url  {{value}} {{error}}.
       Add `x-sandbox: true` to skip this check on a specific server.
     given:
-    -  $.servers[?(@["x-sandbox"] != true)]
-    -  $.paths..servers[?(@["x-sandbox"] != true)]
+    -  $.servers[?(@ && @["x-sandbox"] != true)]
+    -  $.paths..servers[?(@ && @["x-sandbox"] != true)]
     severity: error
     recommended: true
     then:

--- a/rules/naming.yml
+++ b/rules/naming.yml
@@ -32,7 +32,7 @@ rules:
       - oas3
     severity: info
     given: >-
-      $..parameters.[?(@.name && @.name.match && @.name.match(/^(nome|name|surname|cf|fiscal_?code|fiscal_?number|first_?name|last_?name)$/i) )]
+      $..parameters.[?(@ && @.name && @.name.match && @.name.match(/^(nome|name|surname|cf|fiscal_?code|fiscal_?number|first_?name|last_?name)$/i) )]
     then:
       field: "name"
       function: pattern
@@ -83,7 +83,7 @@ rules:
       - oas3
     severity: hint
     given: >-
-      $..[?(@.operationId && @.operationId.match && @.operationId.match(/^(get|post|put|delete|patch|head)/i) )]
+      $..[?(@ && @.operationId && @.operationId.match && @.operationId.match(/^(get|post|put|delete|patch|head)/i) )]
     then:
       field: "operationId"
       function: pattern

--- a/security/array.yml
+++ b/security/array.yml
@@ -28,7 +28,7 @@ rules:
     recommended: true
     given:
     - >-
-      $..[?(@.type=="array")]
+      $..[?(@ && @.type=="array")]
     then:
     - field: maxItems
       function: defined

--- a/security/numbers.yml
+++ b/security/numbers.yml
@@ -14,9 +14,9 @@ rules:
     recommended: true
     given:
     - >-
-      $..[?(@.type=="number")]
+      $..[?(@ && @.type=="number")]
     - >-
-      $..[?(@.type=="integer")]
+      $..[?(@ && @.type=="integer")]
     then:
     - field: maximum
       function: defined

--- a/security/objects.yml
+++ b/security/objects.yml
@@ -49,7 +49,7 @@ rules:
     recommended: true
     given:
       - >-
-        $..[?(@.type=="object" && @.additionalProperties==true)]
+        $..[?(@ && @.type=="object" && @.additionalProperties==true)]
     then:
       - field: additionalProperties
         function: falsy
@@ -57,7 +57,7 @@ rules:
     <<: *object-constraints
     given:
       - >-
-        $..[?(@.type=="object" && ! @.additionalProperties)]
+        $..[?(@ && @.type=="object" && ! @.additionalProperties)]
     then:
       - field: additionalProperties
         function: defined
@@ -65,7 +65,7 @@ rules:
     <<: *object-constraints
     given:
       - >-
-        $..[?(@.type=="object" && @.additionalProperties
+        $..[?(@ && @.type=="object" && @.additionalProperties
         &&  @.additionalProperties!=true
         &&  @.additionalProperties!=false
         )]

--- a/security/securitySchemes.yml
+++ b/security/securitySchemes.yml
@@ -32,7 +32,7 @@ rules:
       JWT usage should be detailed in `description` {{error}}.
     given:
       - >-
-        $..[securitySchemes][?(@.type=="oauth2")]
+        $..[securitySchemes][?(@ && @.type=="oauth2")]
     then:
       - field: description
         function: truthy
@@ -45,4 +45,4 @@ rules:
     <<: *jwt-bcp
     given:
       - >-
-        $..[securitySchemes][?(@.bearerFormat=="jwt" || @.bearerFormat=="JWT")]
+        $..[securitySchemes][?(@ && (@.bearerFormat=="jwt" || @.bearerFormat=="JWT"))]

--- a/security/securitySchemes_insecure.yml
+++ b/security/securitySchemes_insecure.yml
@@ -29,7 +29,7 @@ rules:
     recommended: true
     given:
     - >-
-      $..[securitySchemes][?(@.type=="apiKey")].in
+      $..[securitySchemes][?(@ && @.type=="apiKey")].in
     then:
     - function: pattern
       functionOptions:
@@ -53,7 +53,7 @@ rules:
     severity: error
     given:
     -  >-
-        $..[securitySchemes][?(@.type=="http")].scheme
+        $..[securitySchemes][?(@ && @.type=="http")].scheme
     then:
     - function: pattern
       functionOptions:

--- a/security/string.yml
+++ b/security/string.yml
@@ -38,10 +38,8 @@ rules:
     severity: warn
     recommended: true
     given:
-      - >-
-        $..[?(@.type=="string" && !@.enum
-        && @.format!="date" && @.format !="date-time"
-        )]
+    - >-
+      $..[?(@ && @.type=="string" && !@.enum && !@.format)]
     then:
       - field: maxLength
         function: defined


### PR DESCRIPTION
This PR consolidates all defensive null checks (@ &&) across the rulesets to prevent Spectral crashes. 