### PR TITLE
Refactor 429 Rate-Limit rules

### DIFF
--- a/rules/ratelimit.yml
+++ b/rules/ratelimit.yml
@@ -43,7 +43,7 @@ rules:
     severity: warn
     recommended: true
     given: >-
-      $..[responses][?(@property[0] == "2" || @property[0] == "4")][headers]
+      $..[responses][?(@property[0] == "2" || (@property[0] == "4" && @property != "429"))][headers]
     then:
     - functionOptions:
         properties:
@@ -60,3 +60,53 @@ rules:
           - X-RateLimit-Reset
           - RateLimit-Reset
       function: xor
+
+  ratelimit-429-presence:
+    description: |-
+      429 (Too Many Requests) responses must include either the `Retry-After` header 
+      or a complete set of RateLimit headers (`Limit`, `Remaining`, `Reset`).
+    message: "429 response must have Retry-After or a complete set of RateLimit headers (Limit, Remaining, Reset)."
+    severity: warn
+    formats: [oas3]
+    given: $..[responses][?(@property == "429")][headers]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          anyOf:
+            - required: [Retry-After]
+            - required: [RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset]
+            - required: [X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset]
+
+  ratelimit-429-completeness:
+    description: |-
+      If RateLimit headers are provided for a 429 response, all three headers 
+      (Limit, Remaining, Reset) must be present and follow the same naming convention 
+      (standard or X- prefix). 
+      If both Retry-After and Reset are present, they should ideally represent 
+      the same time interval.
+    message: "RateLimit headers for 429 must be provided as a complete and consistent set."
+    severity: error
+    formats: [oas3]
+    given: >-
+      $..[responses][?(@property == "429")][headers][?(@["X-RateLimit-Limit"] || @["X-RateLimit-Remaining"] || @["X-RateLimit-Reset"] || @["RateLimit-Limit"] || @["RateLimit-Remaining"] || @["RateLimit-Reset"])]
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          oneOf:
+            - allOf:
+                - required: [RateLimit-Limit, RateLimit-Remaining, RateLimit-Reset]
+                - not:
+                    anyOf:
+                      - required: [X-RateLimit-Limit]
+                      - required: [X-RateLimit-Remaining]
+                      - required: [X-RateLimit-Reset]
+            - allOf:
+                - required: [X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset]
+                - not:
+                    anyOf:
+                      - required: [RateLimit-Limit]
+                      - required: [RateLimit-Remaining]
+                      - required: [RateLimit-Reset]
+


### PR DESCRIPTION
Questa PR aggiorna le regole di rate-limit per le risposte 429.
Le modifiche principali includono:
- Esclusione del codice 429 dalla regola generale 'missing-ratelimit'.
- Introduzione di 'ratelimit-429-presence': per il 429 è ora sufficiente avere o l'header 'Retry-After' o il set completo di header di rate-limit.
- Introduzione di 'ratelimit-429-completeness': garantisce che se vengono forniti header di rate-limit, il set sia completo e coerente (standard o prefisso X-).

Nota: il controllo di uguaglianza tra i valori di 'Retry-After' e 'RateLimit-Reset' non è stato implementato a causa delle limitazioni di Spectral nel confronto tra valori di proprietà diverse.