### PR TITLE
feat(rules): update /status endpoint health-check guidelines

### DIFF
--- a/rules/paths.yml
+++ b/rules/paths.yml
@@ -5,8 +5,9 @@ rules:
       Using this path avoids the arbitrary usage of a server URL for health-check
       scope.
 
-      The `/status` endpoint should return a `application/problem+json` response
-      containing a successful status code if the service is working correctly.
+      The `/status` endpoint should return:
+      - a `application/json` response with 200 OK when the service is up.
+      - a `application/problem+json` response with 503 Service Unavailable when the service is down.
 
       The service provider is free to define the implementation logic for this path.
     message: 'The "/status" path must be defined for API health-checks.'
@@ -27,10 +28,10 @@ rules:
           - type: object
             additionalProperties: false
 
-  paths-status-return-problem:
+  paths-status-return-json:
     description: |-
-      "/status" must return a Problem object.
-    message: 'The "/status" endpoint must return "application/problem+json" or "application/problem+xml".'
+      The "/status" endpoint must return "application/json" when the service is Up.
+    message: 'The "/status" (Up) response must be "application/json".'
     severity: error
     recommended: true
     given: >-
@@ -39,26 +40,38 @@ rules:
       function: enumeration
       functionOptions:
         values:
-        - application/problem+xml
+        - application/json
+  paths-status-return-problem:
+    description: |-
+      The "/status" endpoint must return "application/problem+json" for all 4xx and 5xx error responses (Down state).
+    message: 'The "/status" (Down) response ({{property}}) must be "application/problem+json".'
+    severity: error
+    recommended: true
+    given: >-
+      $.paths.'/status'.get.responses[?(@property.match(/^(4|5)/))].content.*~
+    then:
+      function: enumeration
+      functionOptions:
+        values:
         - application/problem+json
   paths-status-problem-schema:
     description: |-
-      "/status" schema is not a Problem object.
-    message: 'The "/status" response schema must include standard Problem fields (status, title, detail).'
+      The "/status" error response (4xx/5xx) must be a Problem object (RFC7807).
+    message: 'The "/status" (Down) response schema ({{property}}) must include standard Problem fields (status, title, detail).'
     severity: warn
     recommended: true
     given: >-
-      $.paths.'/status'.get.responses.200.content.[schema]
+      $.paths.'/status'.get.responses[?(@property.match(/^(4|5)/))].content.[schema]
     then:
     - function: truthy
       field: 'properties.status'
-      message: 'The "/status" response schema must include the standard Problem field "status".'
+      message: 'The "/status" (Down) response schema must include the standard Problem field "status".'
     - function: truthy
       field: 'properties.title'
-      message: 'The "/status" response schema must include the standard Problem field "title".'
+      message: 'The "/status" (Down) response schema must include the standard Problem field "title".'
     - function: truthy
       field: 'properties.detail'
-      message: 'The "/status" response schema must include the standard Problem field "detail".'
+      message: 'The "/status" (Down) response schema must include the standard Problem field "detail".'
   paths-http-method:
     description: |-
       When you design a REST API, you don't usually need to mention terms like


### PR DESCRIPTION
This PR updates the health-check rules for the `/status` endpoint:

- **Up state (200 OK)**: Now requires `application/json` content-type. The body schema is free-form JSON.
- **Down state (4xx/5xx)**: Now requires `application/problem+json` (RFC7807) and must include standard Problem fields (`status`, `title`, `detail`).
- **Terminology**: Simplified rule descriptions and messages to use **Up** and **Down** instead of more verbose terms.