### PR TITLE
fix(rules): add null-guard to prevent crashes on missing headers

### DIFF
--- a/rules/cache-control.yml
+++ b/rules/cache-control.yml
@@ -51,10 +51,16 @@ rules:
     severity: info
     recommended: true
     given: >-
-      $..[responses][?(@property[0] == "2" )][headers]
+      $..[responses][?(@property[0] == "2")][headers]
     then:
-    - function: xor
-      functionOptions:
-        properties:
-        -  Expires
-        -  Cache-Control
+      - function: schema
+        functionOptions:
+          schema:
+            type: object
+            oneOf:
+              - required: [Cache-Control]
+                not:
+                  required: [Expires]
+              - required: [Expires]
+                not:
+                  required: [Cache-Control]

--- a/rules/headers.yml
+++ b/rules/headers.yml
@@ -34,7 +34,7 @@ rules:
     <<: *no-x-headers
     given:
       - $..[responses][*].headers.*~
-    message: "[RFC6648] Avoid using 'X-' prefix for response headers. Use meaningful names instead."
+    message: "[RFC6648] Avoid using 'X-' prefix for response header '{{property}}'. Use a meaningful name instead."
     then:
       function: pattern
       functionOptions:

--- a/rules/naming.yml
+++ b/rules/naming.yml
@@ -27,7 +27,7 @@ rules:
 
 
     message: |-
-      Use recommended variable names in {{value}}.
+      The parameter name '{{value}}' should align with national ontologies. Use standardized names like 'given_name', 'family_name', 'tax_code'.
     formats:
       - oas3
     severity: info
@@ -41,7 +41,7 @@ rules:
     description: |-
       Use well defined parameter and schema names, deriving them
       from the national ontologies available at https://w3id.org/italia/onto/
-    message: "Use recommended variable names in '{{value}}'."
+    message: "The property name '{{value}}' should align with national ontologies. Use standardized names like 'given_name', 'family_name', 'tax_code'."
     formats:
       - oas3
     severity: info
@@ -81,7 +81,7 @@ rules:
       ```
       
     message: |-
-      Avoid using method names in operationIds: {{value}}.
+      The operationId '{{value}}' starts with an HTTP verb (get, post, put, delete, patch). Use a resource-centric name instead.
     formats:
       - oas3
     severity: hint

--- a/rules/oauth2.yml
+++ b/rules/oauth2.yml
@@ -4,7 +4,7 @@ rules:
     description: |-
       OAuth2 endpoints must use `https://`
     message: >-
-      OAuth endpoints must use https://
+      [RFC6749] OAuth2 authorization and token endpoints must use HTTPS.
     formats:
       - oas3
     severity: error

--- a/rules/problem.yml
+++ b/rules/problem.yml
@@ -24,7 +24,7 @@ rules:
       ```
 
     message: |-
-      [RFC7807] Error responses should support RFC7807 in {{path}}.
+      [RFC9457] Error response content type must be 'application/problem+json' or 'application/problem+xml'.
     formats:
       - oas3
     severity: error
@@ -61,7 +61,7 @@ rules:
 
       See recommendation RAC_REST_NAME_007.
     message: |-
-      [RFC7807] Your schema doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+      [RFC9457] Error response schema does not conform to RFC9457. Expected at least two of: 'title', 'status', 'type', 'detail'.
     formats:
     - oas3
     severity: hint
@@ -124,7 +124,7 @@ rules:
 
       See recommendation RAC_REST_NAME_007.
     message: |-
-      [RFC7807] Error response doesn't seem to match RFC7807. Are you sure it is ok? {{path}}
+      [RFC9457] Error response uses non-standard fields ('message', 'code', 'msg'). Replace them with RFC9457 fields: 'detail', 'type', 'status', 'title'.
     formats:
     - oas3
     severity: hint

--- a/rules/ratelimit.yml
+++ b/rules/ratelimit.yml
@@ -37,7 +37,7 @@ rules:
       A standardization proposal for ratelimit headers is ongoing
       inside the IETF HTTPAPI Workgroup.
       See [the draft](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/)
-    message: "Missing or ambiguous rate-limit header: '{{property}}' must be defined (standard or X- prefix)."
+    message: "[RFC7231] 2xx/4xx responses must include all three rate-limit headers (Limit, Remaining, Reset) using one consistent prefix: either 'X-RateLimit-' or 'RateLimit-'."
     formats:
       - oas3
     severity: warn
@@ -45,27 +45,38 @@ rules:
     given: >-
       $..[responses][?(@property[0] == "2" || (@property[0] == "4" && @property != "429"))][headers]
     then:
-    - functionOptions:
-        properties:
-        -  X-RateLimit-Limit
-        -  RateLimit-Limit
-      function: xor
-    - functionOptions:
-        properties:
-          - X-RateLimit-Remaining
-          - RateLimit-Remaining
-      function: xor
-    - functionOptions:
-        properties:
-          - X-RateLimit-Reset
-          - RateLimit-Reset
-      function: xor
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          allOf:
+            - oneOf:
+                - required: [X-RateLimit-Limit]
+                  not:
+                    required: [RateLimit-Limit]
+                - required: [RateLimit-Limit]
+                  not:
+                    required: [X-RateLimit-Limit]
+            - oneOf:
+                - required: [X-RateLimit-Remaining]
+                  not:
+                    required: [RateLimit-Remaining]
+                - required: [RateLimit-Remaining]
+                  not:
+                    required: [X-RateLimit-Remaining]
+            - oneOf:
+                - required: [X-RateLimit-Reset]
+                  not:
+                    required: [RateLimit-Reset]
+                - required: [RateLimit-Reset]
+                  not:
+                    required: [X-RateLimit-Reset]
 
   ratelimit-429-presence:
     description: |-
       429 (Too Many Requests) responses must include either the `Retry-After` header 
       or a complete set of RateLimit headers (`Limit`, `Remaining`, `Reset`).
-    message: "429 response must have Retry-After or a complete set of RateLimit headers (Limit, Remaining, Reset)."
+    message: "[RFC6585] A 429 response must include 'Retry-After' or a full set of rate-limit headers: X-RateLimit-{Limit,Remaining,Reset} or RateLimit-{Limit,Remaining,Reset}."
     severity: warn
     formats: [oas3]
     given: $..[responses][?(@property == "429")][headers]
@@ -85,11 +96,11 @@ rules:
       (standard or X- prefix). 
       If both Retry-After and Reset are present, they should ideally represent 
       the same time interval.
-    message: "RateLimit headers for 429 must be provided as a complete and consistent set."
+    message: "[RFC6585] A 429 response must include all three rate-limit headers (Limit, Remaining, Reset) using one consistent prefix: either 'X-RateLimit-' or 'RateLimit-', never mixed."
     severity: error
     formats: [oas3]
     given: >-
-      $..[responses][?(@property == "429")][headers][?(@["X-RateLimit-Limit"] || @["X-RateLimit-Remaining"] || @["X-RateLimit-Reset"] || @["RateLimit-Limit"] || @["RateLimit-Remaining"] || @["RateLimit-Reset"])]
+      $..[responses][?(@property == "429")][headers][?(@ && (@["X-RateLimit-Limit"] || @["X-RateLimit-Remaining"] || @["X-RateLimit-Reset"] || @["RateLimit-Limit"] || @["RateLimit-Remaining"] || @["RateLimit-Reset"]))]
     then:
       function: schema
       functionOptions:

--- a/rules/schemas.yml
+++ b/rules/schemas.yml
@@ -11,7 +11,7 @@ rules:
       There are notable exceptions when specific media types are involved,
       for example json-patch is an array (see RFC6902).
     message: |-
-      [RFC6902] JSON responses must use json objects (eg "{}"), not {{value}}. {{path}}
+      JSON responses must return an object (`{}`), not {{value}}. Wrap arrays in an object to allow future extensibility (e.g., `{"items": [...]}`). {{path}}
     severity: warn
     recommended: true
     given: 

--- a/rules/secrets-parameters.yml
+++ b/rules/secrets-parameters.yml
@@ -22,7 +22,7 @@ rules:
       ```
 
     message: >-
-      ApiKey passed in URL: {{error}}.
+      [RAC_GEN_004] API key must not be passed as a query parameter. Use header-based authentication (in: header) to prevent exposure in URLs and server logs.
     formats:
     - oas3
     severity: error
@@ -44,7 +44,7 @@ rules:
       See [RAC_GEN_004](https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/04_Raccomandazioni%20di%20implementazione/04_raccomandazioni-tecniche-generali/01_globali.html?highlight=credenziali#rac-gen-004-non-passare-credenziali-o-dati-riservati-nellurl)
 
     message: >-
-      [RAC_GEN_004] Credentials are sent via URLs. {{path}} {{error}}
+      [RAC_GEN_004] Parameter '{{error}}' must not carry credentials (password, secret, API key) in the URL. Move sensitive data to request headers or body.
     formats:
       - oas3
     severity: error


### PR DESCRIPTION
## Null-safety fixes (3 regole)

- **`ratelimit-429-completeness`**: aggiunto `@ &&` null-guard nel filtro secondario JSONPath per prevenire crash in jsonpath-plus quando `[headers]` restituisce null
- **`missing-ratelimit`**: sostituito `xor` con `schema` (`type: object` + `allOf`/`oneOf`) — headers null producono una violazione invece di crashare, semantica di xor preservata
- **`cache-responses-indeterminate-behavior`**: stesso fix di `missing-ratelimit`

## Miglioramenti messaggi (13 regole)

| Regola | Problema risolto |
|--------|-----------------|
| `no-x-headers-response` | Aggiunto `{{property}}` per mostrare l'header incriminato |
| `use-recommended-names-in-parameters` | Chiarito quali nomi usare e perché |
| `use-recommended-names-in-schemas` | Stesso fix |
| `no-method-name-in-operationId` | Elencati i verbi HTTP da evitare |
| `use-problem-json-for-errors` | Riformulazione + RFC7807 → RFC9457 |
| `use-problem-schema` | Rimosso "Are you sure it is ok?"; RFC9457; campi attesi espliciti |
| `hint-problem-schema` | Stesso fix; campi non-standard nominati esplicitamente |
| `response-with-json-object` | Rimossa citazione errata di RFC6902 |
| `sec-apikeys-url` | Spiegato cosa fare invece |
| `sec-credentials-parameters` | `{{error}}` integrato nella frase |
| `sec-securitySchemes-oauth-http` | Aggiunto riferimento RFC6749 |
| `ratelimit-429-presence` | Aggiunto RFC6585 |
| `ratelimit-429-completeness` | Chiarito "complete and consistent"; RFC6585 |
| `missing-ratelimit` | Sostituito messaggio vago con `{{property}}` non funzionante |

## Test plan

- [ ] `make rules` per rigenerare i ruleset
- [ ] `spectral lint openapi-test.yaml --ruleset rulesets/spectral.yml` — nessun errore di runtime
- [ ] Verificare che le violazioni attese siano prodotte con i nuovi messaggi