### PR TITLE
Added "Hint" rule to check OpenAPI compatibility

### DIFF
--- a/rules/oas3only.yml
+++ b/rules/oas3only.yml
@@ -22,3 +22,17 @@ rules:
     then:
       function: truthy
 
+  oas3-version-hint:
+    description: "Suggests using OpenAPI 3.0.x for better compatibility."
+    message: "Working with OpenAPI 3.0.x is recommended for compatibility reasons."
+    severity: hint
+    formats:
+      - oas2
+      - oas3
+    given: $
+    then:
+      field: openapi
+      function: pattern
+      functionOptions:
+        match: ^3\.0\..+$
+


### PR DESCRIPTION
Dettagli della modifica:
   - File modificato: rules/oas3only.yml
   - Nome regola: oas3-version-hint
   - Gravità: hint
   - Comportamento: La regola verifica il campo openapi alla radice del documento. Se il valore non corrisponde al pattern
     ^3\.0\..+$ (ovvero se la versione è diversa da OpenAPI 3.0.x, come ad esempio OpenAPI 3.1.0), viene segnalato un
     suggerimento.

  La regola è stata configurata per essere attiva sia su formati oas2 che oas3 per garantire la massima copertura, anche
  se i file Swagger 2.0 sono già segnalati come errore da una regola preesistente nello stesso file.